### PR TITLE
Switch beta fixes, binary mapper support, resnet alternative

### DIFF
--- a/metacontroller/metacontroller.py
+++ b/metacontroller/metacontroller.py
@@ -560,8 +560,11 @@ class MetaController(Module):
             assert seq_len == 1, 'inference RL phase must be done one token at a time - if replaying for policy optimization, please use `get_action_dist_for_internal_rl`'
             z_prev = prev_sampled_latent_action
 
-        # switch input is previous latent action and the embedding
-        # eq (16)
+        # eq (16): β_t = f_switch(e_t, h_{t-1}, z_{t-1}) ∈ [0, 1]
+        # switch_input = [e_t, h_{t-1}, z_{t-1}]:
+        #   e_t       = residual_stream (current observation/embedding)
+        #   h_{t-1}  = meta_embed_prev (summary GRU output at t-1; switching unit GRU also gets prev_switching_unit_gru_hidden)
+        #   z_{t-1}  = z_prev (previous latent code)
 
         switch_input = cat((
             residual_stream,

--- a/metacontroller/transformer_with_resnet.py
+++ b/metacontroller/transformer_with_resnet.py
@@ -199,6 +199,7 @@ class TransformerWithResnet(Transformer):
         encoder_kwargs: dict | None = None,
         **kwargs
     ):
+        kwargs["state_loss_detach_target_state"] = True
         super().__init__(*args, **kwargs)
         self.is_channel_last = is_channel_last
 


### PR DESCRIPTION
hello everyone,
here I report some fixes hoping to get a better switching unit:

- added support for the binary mapper in the discovery phase
- fixed switch betas processing for visualization and entropy triggering (it needed masking)
- added feasibility restoration when the negative entorpy loss kicks in (temporarily deactivating obs and action recon losses)
- added support for symbolic observations (no resnet, no RGB) in babyAI miniboss
- also, I disabled the use of `train_discovery()` as I noticed the `requires_grad` attributes of the module to disable were not set to `False`! So I manually enforced it.

let me know what you end up seeing on your side!